### PR TITLE
Fix a pointer error in creating the scaling context

### DIFF
--- a/src/software/scaling/context.rs
+++ b/src/software/scaling/context.rs
@@ -56,7 +56,7 @@ impl Context {
                 ptr::null_mut(),
             );
 
-            if ptr.is_null() {
+            if !ptr.is_null() {
                 Ok(Context {
                     ptr: ptr,
 


### PR DESCRIPTION
This is the source of the `Invalid data found when processing input`error when trying to create the scaler. Not entirely sure how it slipped through, but it might be better to use NonNull pointers to check for this instead.